### PR TITLE
Drop experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# [har.fyi](https://har.fyi/) 🧪
+# [har.fyi](https://har.fyi/)
 
 Reference documentation for the [HTTP Archive](https://httparchive.org/) dataset on BigQuery.
 
-This site is still in beta and content will be added gradually. Please [contribute](#contributing) a PR to add new docs or make any corrections!
+Please [contribute](#contributing) a PR to add new docs or make any corrections!
 
 ## Contributing
 
@@ -23,7 +23,7 @@ All commands are run from the root of the project, from a terminal:
 | Command                   | Action                                           |
 | :------------------------ | :----------------------------------------------- |
 | `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:3000`      |
+| `npm run dev`             | Starts local dev server at `localhost:4321`      |
 | `npm run build`           | Build your production site to `./dist/`          |
 | `npm run preview`         | Preview your build locally, before deploying     |
 | `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ export default defineConfig({
   site: 'https://har.fyi',
   integrations: [
     starlight({
-      title: 'har.fyi 🧪',
+      title: 'har.fyi',
       head: [
         {
           tag: 'script',

--- a/public/payload.json
+++ b/public/payload.json
@@ -1010,27 +1010,6 @@
                   "p75": "0.00"
               }
           },
-          "experimental_interaction_to_next_paint": {
-              "histogram": [
-                  {
-                      "start": 0,
-                      "end": 200,
-                      "density": 0.9835904971834437
-                  },
-                  {
-                      "start": 200,
-                      "end": 500,
-                      "density": 0.00979671809943669
-                  },
-                  {
-                      "start": 500,
-                      "density": 0.006612784717119725
-                  }
-              ],
-              "percentiles": {
-                  "p75": 15
-              }
-          },
           "experimental_time_to_first_byte": {
               "histogram": [
                   {

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: har.fyi
 description: Learn how the HTTP Archive (HAR) dataset works and how to use it to explore the state of the web.
 template: splash
 hero:
-  tagline: A new experimental reference doc for the HTTP Archive dataset
+  tagline: A new reference doc for the HTTP Archive dataset
   image:
     file: ../../assets/mag.png
   actions:


### PR DESCRIPTION
Fixes #31 

Also updates default port which [changed in Astro v3](https://github.com/withastro/roadmap/discussions/451#discussioncomment-6949666) since I noticed it was wrong too.

And drops the `experimental_interaction_to_next_paint` metric from the example as it's gone too.