### PR TITLE
Fix Typo in Link

### DIFF
--- a/src/content/docs/reference/tables/pages.mdx
+++ b/src/content/docs/reference/tables/pages.mdx
@@ -96,7 +96,7 @@ See the [Lighthouse](/reference/blobs/lighthouse/) reference for more details.
 
 Blink features detected at runtime (see https://chromestatus.com/features)
 
-See the [Features](/reference/structs/features/) reference for more details.
+See the [Feature](/reference/structs/feature/) reference for more details.
 
 ### `technologies`
 


### PR DESCRIPTION
The link was dead as `features` is called `feature`